### PR TITLE
Change Xenopus to C. elegans

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This program generates many random sequences following the
 sequence profiles of human mature microRNA sequences.
 It produces the final list of the sequences after filtering
-out the potential matches to human, mouse, _Xenopus laevis_, or
+out the potential matches to human, mouse, _Caenorhabditis elegans_, or
 zebrafish microRNAs.
 
 _Hyeshik Chang_


### PR DESCRIPTION
I think _Xenopus_ is less popular in this type of studies. What about using _C.elegans_ instead?

Hye-Yeong Jo.